### PR TITLE
Specify voila options in a configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Materials presented at [BIDS ImageXD
 2021](https://bids.berkeley.edu/events/imagexd-2021).
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cgusb/solidification-tracking.git/main?urlpath=%2Fvoila%2Frender%2Fslideshow.ipynb?voila-template=reveal) (view Voilà slideshow)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cgusb/solidification-tracking.git/main?urlpath=%2Fvoila%2Frender%2Fslideshow.ipynb) (view Voilà slideshow)
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cgusb/solidification-tracking/main?filepath=slideshow.ipynb) (run Jupyter notebook)
 

--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -1,0 +1,6 @@
+{
+    "VoilaConfiguration": {
+        "strip_sources": false,
+        "template": "reveal"
+    }
+}


### PR DESCRIPTION
With this PR, code cells are now visible in the (Jupyter notebook turned) Voilà slideshow deployed on Binder.  

Follows from: https://github.com/voila-dashboards/voila/issues/105#issuecomment-844376107